### PR TITLE
correcting installation instructions for local smac

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -124,7 +124,7 @@ tar -xf hyperopt_august2013_mod_src.tar.gz
 mv hyperopt_august2013_mod_src tpe/
 
 tar -xf smac_2_06_01-dev_src.tar.gz
-mv smac_2_06_01-dev_src.tar.gz smac/
+mv mv smac_2_06_01-dev_src smac/
 
 tar -xf spearmint_april2013_mod_src.tar.gz
 mv spearmint_april2013_mod_src spearmint/


### PR DESCRIPTION
You instruct users to move the archive to the smac folder, when they should actually move the extracted folder.
