### PR TITLE
Changing function call for compatibility with Ubuntu 14.04

### DIFF
--- a/HPOlib/wrapping.py
+++ b/HPOlib/wrapping.py
@@ -48,9 +48,8 @@ logger = logging.getLogger("HPOlib.wrapping")
 
 def get_all_p_for_pgid():
     current_pgid = os.getpgid(os.getpid())
-    pids = psutil.get_pid_list()
     running_pid = []
-    for pid in pids:
+    for pid in psutil.process_iter():
         try:
             pgid = os.getpgid(pid)
         except:


### PR DESCRIPTION
I had to change this to make it run on my Ubuntu 14.04 Virtual Machine. I haven't checked if it provides the exact same functionality as psutil.pids(), which is not present on my system. 
